### PR TITLE
Update kainstall-centos.sh

### DIFF
--- a/kainstall-centos.sh
+++ b/kainstall-centos.sh
@@ -1692,7 +1692,7 @@ function init::add_node() {
   
   if [[ "$MASTER_NODES" != "" ]]; then
     command::exec "${MGMT_NODE}" "
-      kubectl get node --selector='node-role.kubernetes.io/master' -o jsonpath='{\$.items[*].metadata.name}' | grep -Eo '[0-9]+\$'
+      kubectl get node --selector='node-role.kubernetes.io/master' -o jsonpath='{\$.items[*].metadata.name}' |grep -Eo 'node[0-9]*'|grep -Eo '[0-9]*'|awk -F ' ' 'BEGIN {max = 0} {if (\$0+0 > max+0) max=\$0} END {print max}'
     "
     get::command_output "master_index" "$?" "exit"
     master_index=$(( master_index + 1 ))
@@ -1706,7 +1706,7 @@ function init::add_node() {
 
   if [[ "$WORKER_NODES" != "" ]]; then
     command::exec "${MGMT_NODE}" "
-      kubectl get node --selector='!node-role.kubernetes.io/master' -o jsonpath='{\$.items[*].metadata.name}' | grep -Eo '[0-9]+\$' || echo 0
+      kubectl get node --selector='node-role.kubernetes.io/worker' -o jsonpath='{\$.items[*].metadata.name}'| grep -Eo 'node[0-9]*'|grep -Eo '[0-9]*'|awk 'BEGIN {max = 0} {if (\$0+0 > max+0) max=\$0} END {print max}' || echo 0
     "
     get::command_output "worker_index" "$?" "exit"
     worker_index=$(( worker_index + 1 ))

--- a/kainstall-debian.sh
+++ b/kainstall-debian.sh
@@ -1679,7 +1679,7 @@ function init::add_node() {
   
   if [[ "$MASTER_NODES" != "" ]]; then
     command::exec "${MGMT_NODE}" "
-      kubectl get node --selector='node-role.kubernetes.io/master' -o jsonpath='{\$.items[*].metadata.name}' | grep -Eo '[0-9]+\$'
+      kubectl get node --selector='node-role.kubernetes.io/master' -o jsonpath='{\$.items[*].metadata.name}' |grep -Eo 'node[0-9]*'|grep -Eo '[0-9]*'|awk -F ' ' 'BEGIN {max = 0} {if (\$0+0 > max+0) max=\$0} END {print max}'
     "
     get::command_output "master_index" "$?" "exit"
     master_index=$(( master_index + 1 ))
@@ -1693,7 +1693,7 @@ function init::add_node() {
 
   if [[ "$WORKER_NODES" != "" ]]; then
     command::exec "${MGMT_NODE}" "
-      kubectl get node --selector='!node-role.kubernetes.io/master' -o jsonpath='{\$.items[*].metadata.name}' | grep -Eo '[0-9]+\$' || echo 0
+      kubectl get node --selector='node-role.kubernetes.io/worker' -o jsonpath='{\$.items[*].metadata.name}'| grep -Eo 'node[0-9]*'|grep -Eo '[0-9]*'|awk 'BEGIN {max = 0} {if (\$0+0 > max+0) max=\$0} END {print max}' || echo 0
     "
     get::command_output "worker_index" "$?" "exit"
     worker_index=$(( worker_index + 1 ))

--- a/kainstall-ubuntu.sh
+++ b/kainstall-ubuntu.sh
@@ -1680,7 +1680,7 @@ function init::add_node() {
   
   if [[ "$MASTER_NODES" != "" ]]; then
     command::exec "${MGMT_NODE}" "
-      kubectl get node --selector='node-role.kubernetes.io/master' -o jsonpath='{\$.items[*].metadata.name}' | grep -Eo '[0-9]+\$'
+      kubectl get node --selector='node-role.kubernetes.io/master' -o jsonpath='{\$.items[*].metadata.name}' |grep -Eo 'node[0-9]*'|grep -Eo '[0-9]*'|awk -F ' ' 'BEGIN {max = 0} {if (\$0+0 > max+0) max=\$0} END {print max}'
     "
     get::command_output "master_index" "$?" "exit"
     master_index=$(( master_index + 1 ))
@@ -1694,7 +1694,7 @@ function init::add_node() {
 
   if [[ "$WORKER_NODES" != "" ]]; then
     command::exec "${MGMT_NODE}" "
-      kubectl get node --selector='!node-role.kubernetes.io/master' -o jsonpath='{\$.items[*].metadata.name}' | grep -Eo '[0-9]+\$' || echo 0
+      kubectl get node --selector='node-role.kubernetes.io/worker' -o jsonpath='{\$.items[*].metadata.name}'| grep -Eo 'node[0-9]*'|grep -Eo '[0-9]*'|awk 'BEGIN {max = 0} {if (\$0+0 > max+0) max=\$0} END {print max}' || echo 0
     "
     get::command_output "worker_index" "$?" "exit"
     worker_index=$(( worker_index + 1 ))


### PR DESCRIPTION
在超过10个节点时，因为排序为1，10，11，，2，3，4，，，9，通过原脚本获取的最大值为9
```
[root@k8s-master-node1 ~]# kubectl get node --selector='!node-role.kubernetes.io/master' -o jsonpath='{$.items[*].metadata.name}' 
k8s-worker-node1 k8s-worker-node10 k8s-worker-node11 k8s-worker-node2 k8s-worker-node3 k8s-worker-node4 k8s-worker-node9
```
```
[root@k8s-master-node1 ~]# kubectl get node --selector='!node-role.kubernetes.io/master' -o jsonpath='{$.items[*].metadata.name}' | grep -Eo '[0-9]+$' || echo 0
9
```

修改后的脚本获取最大值为11，符合预期
```
[root@k8s-master-node1 ~]# ssh k8s-master-node1 "kubectl get node --selector='node-role.kubernetes.io/worker' -o jsonpath='{\$.items[*].metadata.name}'| grep -Eo 'node[0-9]*'|grep -Eo '[0-9]*'|awk 'BEGIN {max = 0} {if (\$0+0 > max+0) max=\$0} END {print max}' || echo 0 "
11
```

已自测添加worker11正常